### PR TITLE
Add stacked chart element

### DIFF
--- a/assets/js/chart.js
+++ b/assets/js/chart.js
@@ -73,8 +73,74 @@ export async function renderChart(ctx) {
   });
 }
 
+export async function renderStackedChart(ctx) {
+  const data = await loadCSV('assets/data/datahdKH.csv');
+
+  // Parse: date, production and industrial zone name
+  const parsed = data.map(row => {
+    const [day, month, year] = row['Ngày chốt chỉ số'].split('/');
+    const date = new Date(year, month - 1, day);
+    const value = parseFloat(row['Sản lượng'].replace(/\./g, ''));
+    const addr = row['Địa chỉ sử dụng điện'];
+    const match = addr.match(/KCN[^,]*/);
+    const zone = match ? match[0].trim() : 'Khác';
+    return { date, value, zone };
+  });
+
+  // Determine latest closing month
+  const latest = parsed.reduce((m, r) => (r.date > m ? r.date : m), new Date(0));
+
+  // Labels for last 12 months ending at latest
+  const labels = [];
+  for (let i = 11; i >= 0; i--) {
+    const d = new Date(latest.getFullYear(), latest.getMonth() - i, 1);
+    labels.push(`${String(d.getMonth() + 1).padStart(2, '0')}/${d.getFullYear()}`);
+  }
+
+  const zones = [...new Set(parsed.map(p => p.zone))];
+  const zoneSums = Object.fromEntries(zones.map(z => [z, Array(12).fill(0)]));
+
+  parsed.forEach(({ date, value, zone }) => {
+    const diff = (latest.getFullYear() - date.getFullYear()) * 12 + (latest.getMonth() - date.getMonth());
+    if (diff >= 0 && diff < 12) {
+      const idx = 11 - diff;
+      zoneSums[zone][idx] += value;
+    }
+  });
+
+  const datasets = zones.map(z => ({
+    label: z,
+    data: zoneSums[z],
+    borderWidth: 1
+  }));
+
+  new Chart(ctx, {
+    type: 'bar',
+    data: { labels, datasets },
+    options: {
+      responsive: true,
+      scales: { x: { stacked: true }, y: { stacked: true, beginAtZero: true } },
+      plugins: {
+        legend: { position: 'right' },
+        datalabels: {
+          anchor: 'center',
+          align: 'center',
+          color: '#fff',
+          formatter: v => formatNumber(v)
+        }
+      }
+    },
+    plugins: [ChartDataLabels]
+  });
+}
+
 // Tự động gọi vẽ khi DOM sẵn sàng
 document.addEventListener('DOMContentLoaded', () => {
   const ctx = document.getElementById('myChart').getContext('2d');
   renderChart(ctx);
+
+  const stackedEl = document.getElementById('stackedChart');
+  if (stackedEl) {
+    renderStackedChart(stackedEl.getContext('2d'));
+  }
 });

--- a/index.html
+++ b/index.html
@@ -97,6 +97,14 @@
             </div>
           </div>
         </div>
+        <div class="col-md-12 mt-4">
+          <div class="card">
+            <div class="card-body">
+              <h4>Biểu đồ sản lượng theo KCN</h4>
+              <canvas id="stackedChart" style="width: 100%; height: 400px;"></canvas>
+            </div>
+          </div>
+        </div>
       </div> 
     </section>
   </div>


### PR DESCRIPTION
## Summary
- add a canvas with id `stackedChart` in its own card under the main chart
- automatically render the stacked chart if the element exists

## Testing
- `node -e "require('./assets/js/chart.js')"` *(fails: Chart is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68479639ca8c83219083f094bddcf36d