### PR TITLE
Add summary totals row in pivot tables

### DIFF
--- a/assets/js/pivot.js
+++ b/assets/js/pivot.js
@@ -9,6 +9,7 @@ style.textContent = `
   .child-paid { background-color: #e8f5e9; }
   .child-unpaid { background-color: #ffebee; }
   .checkmark { color: green; font-size: 1.2em; text-align: center; }
+  .summary-row { font-weight: bold; background-color: #f0f0f0; }
 `;
 document.head.appendChild(style);
 
@@ -140,6 +141,23 @@ document.addEventListener('DOMContentLoaded', async () => {
           tbody.appendChild(trC);
         });
       });
+
+      const totals = addrData.reduce((acc, r) => {
+        acc.amount += r.amount;
+        acc.active += r.active;
+        acc.reactive += r.reactive;
+        return acc;
+      }, { amount: 0, active: 0, reactive: 0 });
+
+      const trTotal = document.createElement('tr');
+      trTotal.classList.add('summary-row');
+      trTotal.innerHTML = `
+        <td colspan="3" class="text-end">Tổng</td>
+        <td>${formatNumber(totals.amount)}</td>
+        <td>${formatNumber(totals.active)}</td>
+        <td>${formatNumber(totals.reactive)}</td>
+      `;
+      tbody.appendChild(trTotal);
 
       table.appendChild(tbody);
       container.appendChild(table);


### PR DESCRIPTION
## Summary
- include `summary-row` styling in pivot.js
- compute and append totals for each table to show combined amount, active, and reactive values

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68402818682c8321973352fb9e8f4149