### PR TITLE
Add filter cards and dynamic charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,38 @@
       </a>
     </header>
     <section class="section">
+      <div class="row mb-4">
+        <div class="col-md-3 mb-3 mb-md-0">
+          <div class="card text-center">
+            <div class="card-body">
+              <h6 class="card-title">Tổng sản lượng</h6>
+              <h5 id="totalProduction" class="card-text">0</h5>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-3 mb-3 mb-md-0">
+          <div class="card text-center">
+            <div class="card-body">
+              <h6 class="card-title">Tổng doanh thu</h6>
+              <h5 id="totalRevenue" class="card-text">0</h5>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-3 mb-3 mb-md-0">
+          <div class="card">
+            <div class="card-body">
+              <select id="yearSelect" class="form-select"></select>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-3">
+          <div class="card">
+            <div class="card-body">
+              <select id="zoneSelect" class="form-select"></select>
+            </div>
+          </div>
+        </div>
+      </div>
       <div class="row">
         <div class="col-md-12">
           <div class="card">


### PR DESCRIPTION
## Summary
- show total production and revenue cards
- add year and KCN dropdowns for filtering
- redraw Chart.js charts based on filters

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68884aa4cc9883218369e636e14a146d