### PR TITLE
Add filterable dashboard cards

### DIFF
--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -1,0 +1,58 @@
+import { loadData, renderChart, renderStackedChart } from './chart.js';
+import { formatNumberWithUnit } from './format.js';
+
+let chart1 = null;
+let chart2 = null;
+
+function updateTotals(data) {
+  const totalProd = data.reduce((acc, r) => acc + r.value, 0);
+  const totalCost = data.reduce((acc, r) => acc + r.cost, 0);
+  document.getElementById('totalProd').textContent =
+    formatNumberWithUnit(totalProd, 'kWh');
+  document.getElementById('totalCost').textContent =
+    formatNumberWithUnit(totalCost, 'đồng');
+}
+
+function applyFilter(allData) {
+  const yearSel = document.getElementById('yearSelect').value;
+  const zoneSel = document.getElementById('zoneSelect').value;
+
+  const filtered = allData.filter(d =>
+    (yearSel === 'all' || d.date.getFullYear().toString() === yearSel) &&
+    (zoneSel === 'all' || d.zone === zoneSel)
+  );
+
+  updateTotals(filtered);
+
+  if (chart1) chart1.destroy();
+  if (chart2) chart2.destroy();
+  chart1 = renderChart(
+    document.getElementById('myChart').getContext('2d'),
+    filtered
+  );
+  chart2 = renderStackedChart(
+    document.getElementById('stackedChart').getContext('2d'),
+    filtered
+  );
+}
+
+export async function initDashboard() {
+  const data = await loadData();
+  const years = [...new Set(data.map(d => d.date.getFullYear()))].sort();
+  const zones = [...new Set(data.map(d => d.zone))].sort();
+
+  const yearSelect = document.getElementById('yearSelect');
+  yearSelect.innerHTML = '<option value="all">Tất cả</option>';
+  years.forEach(y => yearSelect.add(new Option(y, y)));
+
+  const zoneSelect = document.getElementById('zoneSelect');
+  zoneSelect.innerHTML = '<option value="all">Tất cả</option>';
+  zones.forEach(z => zoneSelect.add(new Option(z, z)));
+
+  yearSelect.addEventListener('change', () => applyFilter(data));
+  zoneSelect.addEventListener('change', () => applyFilter(data));
+
+  applyFilter(data);
+}
+
+document.addEventListener('DOMContentLoaded', initDashboard);

--- a/index.html
+++ b/index.html
@@ -88,6 +88,40 @@
       </a>
     </header>
     <section class="section">
+<div class="row mb-4">
+  <div class="col-md-3">
+    <div class="card">
+      <div class="card-body text-center">
+        <div>Tổng sản lượng</div>
+        <h5 id="totalProd" class="mb-0"></h5>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <div class="card">
+      <div class="card-body text-center">
+        <div>Tổng doanh thu</div>
+        <h5 id="totalCost" class="mb-0"></h5>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <div class="card">
+      <div class="card-body">
+        <label class="form-label" for="yearSelect">Chọn năm</label>
+        <select id="yearSelect" class="form-select"></select>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <div class="card">
+      <div class="card-body">
+        <label class="form-label" for="zoneSelect">Chọn KCN</label>
+        <select id="zoneSelect" class="form-select"></select>
+      </div>
+    </div>
+  </div>
+</div>
       <div class="row">
         <div class="col-md-12">
           <div class="card">
@@ -108,8 +142,7 @@
       </div> 
     </section>
   </div>
-  <script type="module" src="./assets/js/chart.js"></script>
-  <script type="module" src="./assets/js/pivot.js"></script>
+  <script type="module" src="./assets/js/dashboard.js"></script>
   <script src="./assets/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add top summary cards for totals and dropdowns
- implement dashboard logic with dynamic filtering
- adjust chart.js to expose reusable functions
- remove unused pivot script from index

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68884aa4cc9883218369e636e14a146d