### PR TITLE
Fix chart resizing

### DIFF
--- a/assets/js/chart.js
+++ b/assets/js/chart.js
@@ -160,9 +160,14 @@ function renderStacked(filtered, zoneFilter) {
   });
 }
 
+function getActiveValue(listId) {
+  const active = document.querySelector(`#${listId} .active`);
+  return active ? active.dataset.value : 'all';
+}
+
 function applyFilters() {
-  const yearValue = document.getElementById('yearSelect').value;
-  const zoneValue = document.getElementById('zoneSelect').value;
+  const yearValue = getActiveValue('yearList');
+  const zoneValue = getActiveValue('zoneList');
   const filtered = rawData.filter(r =>
     (yearValue === 'all' || r.date.getFullYear() === parseInt(yearValue, 10)) &&
     (zoneValue === 'all' || r.zone === zoneValue)
@@ -186,18 +191,32 @@ async function init() {
   years = [...new Set(rawData.map(r => r.date.getFullYear()))].sort();
   zones = [...new Set(rawData.map(r => r.zone))].sort();
 
-  const yearSelect = document.getElementById('yearSelect');
-  const zoneSelect = document.getElementById('zoneSelect');
-  if (yearSelect) {
-    yearSelect.innerHTML = '<option value="all">Tất cả</option>' +
-      years.map(y => `<option value="${y}">${y}</option>`).join('');
+  const yearList = document.getElementById('yearList');
+  const zoneList = document.getElementById('zoneList');
+  if (yearList) {
+    yearList.innerHTML =
+      '<li class="list-group-item active" data-value="all">Tất cả</li>' +
+      years.map(y => `<li class="list-group-item" data-value="${y}">${y}</li>`).join('');
+    yearList.addEventListener('click', e => {
+      const item = e.target.closest('li');
+      if (!item) return;
+      yearList.querySelectorAll('li').forEach(li => li.classList.remove('active'));
+      item.classList.add('active');
+      applyFilters();
+    });
   }
-  if (zoneSelect) {
-    zoneSelect.innerHTML = '<option value="all">Tất cả</option>' +
-      zones.map(z => `<option value="${z}">${z}</option>`).join('');
+  if (zoneList) {
+    zoneList.innerHTML =
+      '<li class="list-group-item active" data-value="all">Tất cả</li>' +
+      zones.map(z => `<li class="list-group-item" data-value="${z}">${z}</li>`).join('');
+    zoneList.addEventListener('click', e => {
+      const item = e.target.closest('li');
+      if (!item) return;
+      zoneList.querySelectorAll('li').forEach(li => li.classList.remove('active'));
+      item.classList.add('active');
+      applyFilters();
+    });
   }
-  yearSelect.addEventListener('change', applyFilters);
-  zoneSelect.addEventListener('change', applyFilters);
 
   applyFilters();
 }

--- a/assets/js/chart.js
+++ b/assets/js/chart.js
@@ -1,70 +1,74 @@
 import { loadCSV } from './csvReader.js';
 import { formatNumber, formatNumberWithUnit } from './format.js';
 
-// Chart.js plugin data labels (tải qua <script> trong HTML)
 Chart.register(ChartDataLabels);
 
-export async function renderChart(ctx) {
-  const data = await loadCSV('assets/data/datahdKH.csv');
+let rawData = [];
+let years = [];
+let zones = [];
+let chart1;
+let chart2;
 
-  // Parse
-  const parsed = data.map(row => {
-    const [day, month, year] = row['Ngày chốt chỉ số'].split('/');
-    const date = new Date(year, month - 1, day);
-    const value = parseFloat(row['Sản lượng'].replace(/\./g, ''));
-    const cost  = parseFloat(row['Doanh thu'].replace(/\./g, ''));
-    return { date, value, cost };
-  });
+function updateTotals(data) {
+  const totalProd = data.reduce((s, r) => s + r.value, 0);
+  const totalCost = data.reduce((s, r) => s + r.cost, 0);
+  document.getElementById('totalProduction').textContent =
+    formatNumberWithUnit(totalProd, 'kWh');
+  document.getElementById('totalRevenue').textContent =
+    formatNumberWithUnit(totalCost, 'đồng');
+}
 
-  // Danh sách năm và khởi tạo tổng theo tháng
-  const years = [...new Set(parsed.map(i => i.date.getFullYear()))].sort();
-  const monthlySums = Object.fromEntries(years.map(y => [y, Array(12).fill(0)]));
-  parsed.forEach(({ date, value }) => {
-    monthlySums[date.getFullYear()][date.getMonth()] += value;
-  });
-  const monthlyCosts = Object.fromEntries(years.map(y => [y, Array(12).fill(0)]));
-  parsed.forEach(({ date, cost }) => {
-    monthlyCosts[date.getFullYear()][date.getMonth()] += cost;
-  });
-  // Nhãn trục X: Tháng 1–12
-  const labels = Array.from({ length: 12 }, (_, i) => `Tháng ${i+1}`);
+function renderMainChart(filtered, yearFilter) {
+  const ctx = document.getElementById('myChart').getContext('2d');
+  if (chart1) {
+    chart1.destroy();
+    ctx.canvas.style.width = '100%';
+    ctx.canvas.style.height = '400px';
+  }
 
-  // Tạo datasets, mỗi năm một dataset
-  const datasets = years.map(y => ({
+  const yearsToShow = yearFilter === 'all' ? years : [parseInt(yearFilter, 10)];
+  const monthly = {};
+  const monthlyCost = {};
+  yearsToShow.forEach(y => {
+    monthly[y] = Array(12).fill(0);
+    monthlyCost[y] = Array(12).fill(0);
+  });
+  filtered.forEach(r => {
+    const y = r.date.getFullYear();
+    if (!monthly[y]) return;
+    monthly[y][r.date.getMonth()] += r.value;
+    monthlyCost[y][r.date.getMonth()] += r.cost;
+  });
+  const labels = Array.from({ length: 12 }, (_, i) => `Tháng ${i + 1}`);
+  const datasets = yearsToShow.map(y => ({
     label: `Năm ${y}`,
-    data: monthlySums[y],
+    data: monthly[y],
     borderWidth: 1
   }));
 
-  // Vẽ biểu đồ cột nhóm
-  new Chart(ctx, {
+  chart1 = new Chart(ctx, {
     type: 'bar',
     data: { labels, datasets },
     options: {
       responsive: true,
       layout: { padding: { top: 20 } },
       scales: {
-        y: {
-          beginAtZero: true,
-          title: { display: true, text: 'Sản lượng (kWh)' }
-        }
+        y: { beginAtZero: true, title: { display: true, text: 'Sản lượng (kWh)' } }
       },
       plugins: {
         legend: { position: 'bottom' },
-        // Hiển thị số trên đỉnh cột (không kèm đơn vị)
         datalabels: {
           anchor: 'end',
           align: 'top',
-          formatter: (value) => formatNumber(value)
+          formatter: v => formatNumber(v)
         },
-        // Tooltip hiển thị số kèm ' kWh'
         tooltip: {
           callbacks: {
-            label: (ctx) => {
-              const month = ctx.dataIndex;
-              const year  = years[ctx.datasetIndex];
-              const prod  = ctx.raw;
-              const cost  = monthlyCosts[year][month];
+            label: ctx => {
+              const m = ctx.dataIndex;
+              const y = yearsToShow[ctx.datasetIndex];
+              const prod = ctx.raw;
+              const cost = monthlyCost[y][m];
               return [
                 `Sản lượng: ${formatNumberWithUnit(prod, 'kWh')}`,
                 `Doanh thu: ${formatNumberWithUnit(cost, 'đồng')}`
@@ -78,53 +82,41 @@ export async function renderChart(ctx) {
   });
 }
 
-export async function renderStackedChart(ctx) {
-  const data = await loadCSV('assets/data/datahdKH.csv');
+function renderStacked(filtered, zoneFilter) {
+  const ctx = document.getElementById('stackedChart').getContext('2d');
+  if (chart2) {
+    chart2.destroy();
+    ctx.canvas.style.width = '100%';
+    ctx.canvas.style.height = '400px';
+  }
 
-  // Parse: date, production and industrial zone name
-  const parsed = data.map(row => {
-    const [day, month, year] = row['Ngày chốt chỉ số'].split('/');
-    const date = new Date(year, month - 1, day);
-    const value = parseFloat(row['Sản lượng'].replace(/\./g, ''));
-    const cost  = parseFloat(row['Doanh thu'].replace(/\./g, ''));
-    const addr  = row['Địa chỉ sử dụng điện'];
-    const match = addr.match(/KCN[^,]*/);
-    const zone  = match ? match[0].trim() : 'Khác';
-    return { date, value, cost, zone };
-  });
-
-  // Determine latest closing month
-  const latest = parsed.reduce((m, r) => (r.date > m ? r.date : m), new Date(0));
-
-  // Labels for last 12 months ending at latest
+  const latest = filtered.reduce((m, r) => (r.date > m ? r.date : m), new Date(0));
   const labels = [];
   for (let i = 11; i >= 0; i--) {
     const d = new Date(latest.getFullYear(), latest.getMonth() - i, 1);
     labels.push(`${String(d.getMonth() + 1).padStart(2, '0')}/${d.getFullYear()}`);
   }
 
-  const zones = [...new Set(parsed.map(p => p.zone))];
-  const zoneSums  = Object.fromEntries(zones.map(z => [z, Array(12).fill(0)]));
-  const zoneCosts = Object.fromEntries(zones.map(z => [z, Array(12).fill(0)]));
+  const zonesToShow = zoneFilter === 'all' ? zones : [zoneFilter];
+  const zoneSum = Object.fromEntries(zonesToShow.map(z => [z, Array(12).fill(0)]));
+  const zoneCost = Object.fromEntries(zonesToShow.map(z => [z, Array(12).fill(0)]));
   const monthlyTotal = Array(12).fill(0);
 
-  parsed.forEach(({ date, value, cost, zone }) => {
-    const diff = (latest.getFullYear() - date.getFullYear()) * 12 + (latest.getMonth() - date.getMonth());
+  filtered.forEach(r => {
+    if (!zonesToShow.includes(r.zone)) return;
+    const diff = (latest.getFullYear() - r.date.getFullYear()) * 12 +
+                 (latest.getMonth() - r.date.getMonth());
     if (diff >= 0 && diff < 12) {
       const idx = 11 - diff;
-      zoneSums[zone][idx] += value;
-      zoneCosts[zone][idx] += cost;
-      monthlyTotal[idx] += value;
+      zoneSum[r.zone][idx] += r.value;
+      zoneCost[r.zone][idx] += r.cost;
+      monthlyTotal[idx] += r.value;
     }
   });
 
-  const datasets = zones.map(z => ({
-    label: z,
-    data: zoneSums[z],
-    borderWidth: 1
-  }));
+  const datasets = zonesToShow.map(z => ({ label: z, data: zoneSum[z], borderWidth: 1 }));
 
-  new Chart(ctx, {
+  chart2 = new Chart(ctx, {
     type: 'bar',
     data: { labels, datasets },
     options: {
@@ -150,11 +142,11 @@ export async function renderStackedChart(ctx) {
         },
         tooltip: {
           callbacks: {
-            label: (ctx) => {
+            label: ctx => {
               const idx = ctx.dataIndex;
-              const zone = zones[ctx.datasetIndex];
-              const prod = zoneSums[zone][idx];
-              const cost = zoneCosts[zone][idx];
+              const z = zonesToShow[ctx.datasetIndex];
+              const prod = zoneSum[z][idx];
+              const cost = zoneCost[z][idx];
               return [
                 `Sản lượng: ${formatNumberWithUnit(prod, 'kWh')}`,
                 `Doanh thu: ${formatNumberWithUnit(cost, 'đồng')}`
@@ -168,13 +160,46 @@ export async function renderStackedChart(ctx) {
   });
 }
 
-// Tự động gọi vẽ khi DOM sẵn sàng
-document.addEventListener('DOMContentLoaded', () => {
-  const ctx = document.getElementById('myChart').getContext('2d');
-  renderChart(ctx);
+function applyFilters() {
+  const yearValue = document.getElementById('yearSelect').value;
+  const zoneValue = document.getElementById('zoneSelect').value;
+  const filtered = rawData.filter(r =>
+    (yearValue === 'all' || r.date.getFullYear() === parseInt(yearValue, 10)) &&
+    (zoneValue === 'all' || r.zone === zoneValue)
+  );
+  updateTotals(filtered);
+  renderMainChart(filtered, yearValue);
+  renderStacked(filtered, zoneValue);
+}
 
-  const stackedEl = document.getElementById('stackedChart');
-  if (stackedEl) {
-    renderStackedChart(stackedEl.getContext('2d'));
+async function init() {
+  const data = await loadCSV('assets/data/datahdKH.csv');
+  rawData = data.map(row => {
+    const [d, m, y] = row['Ngày chốt chỉ số'].split('/');
+    const date = new Date(y, m - 1, d);
+    const value = parseFloat(row['Sản lượng'].replace(/\./g, '')) || 0;
+    const cost = parseFloat(row['Doanh thu'].replace(/\./g, '')) || 0;
+    const match = row['Địa chỉ sử dụng điện'].match(/KCN[^,]*/);
+    const zone = match ? match[0].trim() : 'Khác';
+    return { date, value, cost, zone };
+  });
+  years = [...new Set(rawData.map(r => r.date.getFullYear()))].sort();
+  zones = [...new Set(rawData.map(r => r.zone))].sort();
+
+  const yearSelect = document.getElementById('yearSelect');
+  const zoneSelect = document.getElementById('zoneSelect');
+  if (yearSelect) {
+    yearSelect.innerHTML = '<option value="all">Tất cả</option>' +
+      years.map(y => `<option value="${y}">${y}</option>`).join('');
   }
-});
+  if (zoneSelect) {
+    zoneSelect.innerHTML = '<option value="all">Tất cả</option>' +
+      zones.map(z => `<option value="${z}">${z}</option>`).join('');
+  }
+  yearSelect.addEventListener('change', applyFilters);
+  zoneSelect.addEventListener('change', applyFilters);
+
+  applyFilters();
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/index.html
+++ b/index.html
@@ -88,6 +88,38 @@
       </a>
     </header>
     <section class="section">
+      <div class="row mb-4">
+        <div class="col-md-3 mb-3 mb-md-0">
+          <div class="card text-center">
+            <div class="card-body">
+              <h6 class="card-title">Tổng sản lượng</h6>
+              <h5 id="totalProduction" class="card-text">0</h5>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-3 mb-3 mb-md-0">
+          <div class="card text-center">
+            <div class="card-body">
+              <h6 class="card-title">Tổng doanh thu</h6>
+              <h5 id="totalRevenue" class="card-text">0</h5>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-3 mb-3 mb-md-0">
+          <div class="card">
+            <div class="card-body">
+              <select id="yearSelect" class="form-select"></select>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-3">
+          <div class="card">
+            <div class="card-body">
+              <select id="zoneSelect" class="form-select"></select>
+            </div>
+          </div>
+        </div>
+      </div>
       <div class="row">
         <div class="col-md-12">
           <div class="card">

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
     </header>
     <section class="section">
       <div class="row mb-4">
-        <div class="col-md-3 mb-3 mb-md-0">
+        <div class="col-md-6 mb-3 mb-md-0">
           <div class="card text-center">
             <div class="card-body">
               <h6 class="card-title">Tổng sản lượng</h6>
@@ -97,7 +97,7 @@
             </div>
           </div>
         </div>
-        <div class="col-md-3 mb-3 mb-md-0">
+        <div class="col-md-6 mb-3 mb-md-0">
           <div class="card text-center">
             <div class="card-body">
               <h6 class="card-title">Tổng doanh thu</h6>
@@ -105,39 +105,43 @@
             </div>
           </div>
         </div>
-        <div class="col-md-3 mb-3 mb-md-0">
-          <div class="card">
-            <div class="card-body">
-              <select id="yearSelect" class="form-select"></select>
-            </div>
-          </div>
-        </div>
-        <div class="col-md-3">
-          <div class="card">
-            <div class="card-body">
-              <select id="zoneSelect" class="form-select"></select>
-            </div>
-          </div>
-        </div>
       </div>
       <div class="row">
-        <div class="col-md-12">
-          <div class="card">
+        <div class="col-md-9">
+          <div class="card h-100">
             <div class="card-body">
               <h4>Biểu đồ phụ tải năm </h4>
               <canvas id="myChart" style="width: 100%; height: 400px;"></canvas>
             </div>
           </div>
         </div>
-        <div class="col-md-12 mt-4">
-          <div class="card">
+        <div class="col-md-3 mt-3 mt-md-0">
+          <div class="card h-100">
+            <div class="card-body">
+              <h6 class="card-title">Năm</h6>
+              <ul id="yearList" class="list-group"></ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="row mt-4">
+        <div class="col-md-9">
+          <div class="card h-100">
             <div class="card-body">
               <h4>Biểu đồ sản lượng theo KCN</h4>
               <canvas id="stackedChart" style="width: 100%; height: 400px;"></canvas>
             </div>
           </div>
         </div>
-      </div> 
+        <div class="col-md-3 mt-3 mt-md-0">
+          <div class="card h-100">
+            <div class="card-body">
+              <h6 class="card-title">Khu công nghiệp</h6>
+              <ul id="zoneList" class="list-group"></ul>
+            </div>
+          </div>
+        </div>
+      </div>
     </section>
   </div>
   <script type="module" src="./assets/js/chart.js"></script>


### PR DESCRIPTION
## Summary
- reset canvas sizing when charts are destroyed so redraws keep the same dimensions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68884aa4cc9883218369e636e14a146d